### PR TITLE
Add links to discourse and mailing list on all issue trackers

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Fortran-lang discourse
+    url: https://fortran-lang.discourse.group/
+    about: Discussion about all things Fortran
+  - name: Fortran-lang mailing list
+    url: https://groups.io/g/fortran-lang
+    about: Mailinglist for the Fortran language

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 This repository holds our central community resources, like the community-wide
 [Code of Conduct](CODE_OF_CONDUCT.md) and other documents.
 
+The [configuration for the issue templates](.github/ISSUE_TEMPLATE/config.yml) allows
+to add additional entries referencing external resources to the issue trackers,
+like [our discourse](https://fortran-lang.discourse.group/) or
+[our mailing list](https://groups.io/g/fortran-lang).
+
 
 ## Contributing to fortran-lang
 


### PR DESCRIPTION
*This patch is purposely send from the default branch of my fork.*

I found an option to add links to the fortran-lang discourse and mailing list using the issue template configuration file. See here how this would look like: https://github.com/awvwgk/fortran-lang-community-files/issues/new/choose

Merging this patch applies the setting to all repositories in the @fortran-lang namespace.