### PR TITLE
Add governance guide

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,47 @@
+# Fortran-lang governance
+
+This page describes the governance model used by the Fortran-lang community. The Fortran-lang community is a volunteer-based effort and relies on its contributors' motivation, free time, and hard work. Administrators, maintainers, and contributors choose to participate and may choose to leave any time for any or no reason.
+
+## Code of Conduct
+
+Any contribution to the Fortran-lang community must follow the [code of conduct](https://github.com/fortran-lang/.github/blob/main/CODE_OF_CONDUCT.md).
+
+## Administrators
+
+The administrators are responsible for keeping Fortran-lang operational. They have access to the following assets
+
+- the Fortran-lang GitHub organization and can invite members, give write-access to projects, and create teams
+- the Fortran-lang Discourse and can give moderator privileges as well as moderate the forum
+- the fortran-lang.org domain
+- the @fortranlang Twitter account (https://twitter.com/fortranlang)
+- the Fortran-lang YouTube channel (https://www.youtube.com/user/Fortran%20Programming%20Language)
+- the Fortran-lang mailing list (https://groups.io/g/fortran-lang)
+
+Maintainers and contributors should contact the administrators in case any action for those assets is required.
+
+Current administrators are
+
+- Ondřej Čertík ([@certik](https://github.com/certik), ondrej@certik.us)
+- Milan Curcic ([@milancurcic](https://github.com/milancurcic), milancurcic@hey.com)
+- Sebastian Ehlert ([@awvwgk](https://github.com/awvwgk), awvwgk@disroot.org)
+- Laurence Kedward ([@lkedward](https://github.com/lkedward), laurence.kedward@bristol.ac.uk)
+
+## Maintainers
+
+The maintainers are responsible for organizing the core projects of Fortran-lang, like the package manager, the standard library, and the webpage. Maintainers are responsible for
+
+- coordinating (larger) projects and steering long-term plans
+- helping new contributors to get acquainted with the project and provide guidance for their first contribution
+- guiding new reviewers to provide comments and feedback for code contributions in pull requests and patches
+- keeping the issue tracker and project boards organized
+- making releases and determining their content
+
+Unless specially required, all discussions and activities of the maintainers will be public and made in collaboration with the community and contributors. Private communications or decisions made by the maintainers will be summarized to the community and contributors publicly after removing personal, private, or sensitive information, that should not be posted publicly on the internet.
+
+## Contributors
+
+Everybody is welcome to contribute to Fortran-lang and its projects. Providing and discussing ideas as well as developing concepts and designs are integral contributions to any project. All contributors can steer and add to the long-term vision of the Fortran-lang projects.
+
+## License
+
+To the extent possible under law, the authors have waived all copyright and related or neighboring rights to the Fortran-lang community governance document, as per the CC-0 public domain dedication.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Community resources for fortran-lang
 
 This repository holds our central community resources, like the community-wide
-[Code of Conduct](CODE_OF_CONDUCT.md) and other documents.
+[Code of Conduct](CODE_OF_CONDUCT.md), [Governance guide](GOVERNANCE.md), and
+other documents.
 
 The [configuration for the issue templates](.github/ISSUE_TEMPLATE/config.yml) allows
 to add additional entries referencing external resources to the issue trackers,


### PR DESCRIPTION
I suggest adding this doc to the .github repo, and then we should discuss if and how we should best display it on fortran-lang.org/community.